### PR TITLE
todo_pageのUIを修正

### DIFF
--- a/lib/presentation/pages/home/todo/todo_page.dart
+++ b/lib/presentation/pages/home/todo/todo_page.dart
@@ -19,26 +19,46 @@ class _TodoPageState extends ConsumerState<TodoPage> {
   Widget build(BuildContext context) {
     final inCompleteTodoListAsync = ref.watch(incompleteTodoProvider);
     return Scaffold(
-      appBar: const CustomAppBar(
-        title: 'マイタスク',
-        subTitle: 'タスクが3件残っています',
-      ),
-      body: inCompleteTodoListAsync.when(
-        data: (inCompleteTodoList) {
-          if (inCompleteTodoList.isEmpty) {
-            return const Center(
-              child: Text('Todoがありません。'),
-            );
-          }
-          return ListView.builder(
-              itemCount: inCompleteTodoList.length,
-              itemBuilder: (context, index) {
-                final inCompleteTodo = inCompleteTodoList[index];
-                return TodoCard(todoModel: inCompleteTodo);
-              });
+      appBar: inCompleteTodoListAsync.when(
+        data: (todoList) {
+          final todoCount = todoList.length;
+          return CustomAppBar(
+            title: 'マイタスク',
+            subTitle: todoCount > 0 ? 'タスクが$todoCount件残っています' : 'タスクはありません',
+          );
         },
-        error: (error, stackTrace) => ErrorPage(error: error),
-        loading: () => const LoadingPage(),
+        error: (error, stackTrace) {
+          return const CustomAppBar(
+            title: 'マイタスク',
+            subTitle: 'タスクの取得に失敗しました',
+          );
+        },
+        loading: () {
+          return const CustomAppBar(
+            title: 'マイタスク',
+            subTitle: 'タスクを取得中です',
+          );
+        },
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: inCompleteTodoListAsync.when(
+          data: (inCompleteTodoList) {
+            if (inCompleteTodoList.isEmpty) {
+              return const Center(
+                child: Text('Todoがありません。'),
+              );
+            }
+            return ListView.builder(
+                itemCount: inCompleteTodoList.length,
+                itemBuilder: (context, index) {
+                  final inCompleteTodo = inCompleteTodoList[index];
+                  return TodoCard(todoModel: inCompleteTodo);
+                });
+          },
+          error: (error, stackTrace) => ErrorPage(error: error),
+          loading: () => const LoadingPage(),
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         child: const Icon(Icons.add),


### PR DESCRIPTION
## ticket

#16 
#30 

## 概要

- todo_pageのUIを修正
- AppBarのサブタイトルをタスクの数に応じて変更（データ取得失敗時のテキストも用意）